### PR TITLE
Add zone to gcloud container clusters create nomad command

### DIFF
--- a/docs/03-kubernetes-infrastructure.md
+++ b/docs/03-kubernetes-infrastructure.md
@@ -47,7 +47,8 @@ gcloud container node-pools create vault-pool \
   --cluster nomad \
   --machine-type n1-standard-2 \
   --num-nodes 2 \
-  --node-labels dedicated=vault
+  --node-labels dedicated=vault \
+  --zone us-east1-b
 ```
 
 > Estimated time to completion: 2 minutes.

--- a/docs/03-kubernetes-infrastructure.md
+++ b/docs/03-kubernetes-infrastructure.md
@@ -14,7 +14,8 @@ A Kubernetes 1.7.3+ cluster is required to host the Nomad control plane componen
 gcloud container clusters create nomad \
   --cluster-version 1.7.3 \
   --machine-type n1-standard-2 \
-  --num-nodes 3
+  --num-nodes 3 \
+  --zone us-east1-b
 ```
 
 It can take several minutes to provision the `nomad` Kubernetes cluster. Either wait for the above command to complete or use the `gcloud` command to monitor progress in a separate terminal:


### PR DESCRIPTION
When I run the command, it complains that I don't have --zone:
```
$ gcloud container clusters create nomad   --cluster-version 1.7.3   --machine-type n1-standard-2   --num-nodes 3
ERROR: (gcloud.container.clusters.create) One of [--zone] must be supplied: Please specify zone
```