### PR TITLE
added gcloud default configuration to docs

### DIFF
--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -15,4 +15,11 @@ Install the following client tools and ensure they are in your path:
 
 > Install kubectl using gcloud: gcloud components install kubectl
 
+Configure default zone and project in in gcloud:
+
+`gcloud config set compute/zone <zone>` ([Google Cloud Regions and Zones](https://cloud.google.com/compute/docs/regions-zones/regions-zones))
+
+`gcloud projects create k8snomad --name Nomad`
+`gcloud config set project k8snomad`
+
 Next: [Provision The Kubernetes Infrastructure](03-kubernetes-infrastructure.md)


### PR DESCRIPTION
The only hiccup I had was getting gcloud set up. For a fresh install, I didn't have a default project or zone set up, so eventually I found the use of the config command to set defaults that let me precede. I added what I used for others.

Hope it is useful!