### PR TITLE
add single quotes to jsonpath arg

### DIFF
--- a/docs/03-kubernetes-infrastructure.md
+++ b/docs/03-kubernetes-infrastructure.md
@@ -90,7 +90,7 @@ Ensure nodes in the `vault-pool` node pool only accept Vault workloads by [taint
 
 ```
 kubectl taint nodes \
-  $(kubectl get nodes -l dedicated=vault -o jsonpath={.items[*].metadata.name}) \
+  $(kubectl get nodes -l dedicated=vault -o jsonpath='{.items[*].metadata.name}') \
   dedicated=vault:NoSchedule
 ```
 


### PR DESCRIPTION
Very simple quoting fix for the `jsonpath` arg.