### PR TITLE
Halve resources

### DIFF
--- a/docs/03-kubernetes-infrastructure.md
+++ b/docs/03-kubernetes-infrastructure.md
@@ -8,7 +8,7 @@ Kubernetes will be used to host the Nomad control plane including the following 
 
 ## Provision a Kubernetes Cluster
 
-A Kubernetes 1.7.3+ cluster is required to host the Nomad control plane components. Use the `gcloud` command to provision a three node Kubernetes cluster:
+A Kubernetes 1.7.3+ cluster is required to host the Nomad control plane components. Use the `gcloud` command to provision a four node Kubernetes cluster:
 
 ```
 gcloud container clusters create nomad \
@@ -24,7 +24,7 @@ gcloud container clusters list
 ```
 ```
 NAME   ZONE           MASTER_VERSION  MASTER_IP      MACHINE_TYPE   NODE_VERSION  NUM_NODES  STATUS
-nomad  us-central1-f  1.7.3           XX.XXX.XXX.XX  n1-standard-2  1.7.3         3          PROVISIONING
+nomad  us-central1-f  1.7.3           XX.XXX.XXX.XX  n1-standard-2  1.7.3         4          PROVISIONING
 ```
 
 > Estimated time to completion: 5 minutes.
@@ -34,7 +34,7 @@ gcloud container clusters list
 ```
 ```
 NAME   ZONE           MASTER_VERSION  MASTER_IP      MACHINE_TYPE   NODE_VERSION  NUM_NODES  STATUS
-nomad  us-central1-f  1.7.3           XX.XXX.XXX.XX  n1-standard-2  1.7.3         3          RUNNING
+nomad  us-central1-f  1.7.3           XX.XXX.XXX.XX  n1-standard-2  1.7.3         4          RUNNING
 ```
 
 ### Provision a Vault Node Pool
@@ -70,7 +70,7 @@ gcloud container clusters list
 
 ```
 NAME   ZONE           MASTER_VERSION  MASTER_IP      MACHINE_TYPE   NODE_VERSION  NUM_NODES  STATUS
-nomad  us-central1-f  1.7.3           XXX.XXX.XX.XX  n1-standard-2  1.7.3         5          RECONCILING
+nomad  us-central1-f  1.7.3           XXX.XXX.XX.XX  n1-standard-2  1.7.3         6          RECONCILING
 ```
 
 > Estimated time to completion: 3 minutes.
@@ -81,7 +81,7 @@ gcloud container clusters list
 
 ```
 NAME   ZONE           MASTER_VERSION  MASTER_IP      MACHINE_TYPE   NODE_VERSION  NUM_NODES  STATUS
-nomad  us-central1-f  1.7.3           XXX.XXX.XX.XX  n1-standard-2  1.7.3         5          RUNNING
+nomad  us-central1-f  1.7.3           XXX.XXX.XX.XX  n1-standard-2  1.7.3         6          RUNNING
 ```
 
 ### Taint the Vault Node Pool

--- a/docs/03-kubernetes-infrastructure.md
+++ b/docs/03-kubernetes-infrastructure.md
@@ -13,7 +13,7 @@ A Kubernetes 1.7.3+ cluster is required to host the Nomad control plane componen
 ```
 gcloud container clusters create nomad \
   --cluster-version 1.7.3 \
-  --machine-type n1-standard-2 \
+  --machine-type n1-standard-1 \
   --num-nodes 3
 ```
 
@@ -44,7 +44,7 @@ Add an additional node pool to support running Vault on a dedicated set of machi
 ```
 gcloud container node-pools create vault-pool \
   --cluster nomad \
-  --machine-type n1-standard-2 \
+  --machine-type n1-standard-1 \
   --num-nodes 2 \
   --node-labels dedicated=vault
 ```

--- a/docs/03-kubernetes-infrastructure.md
+++ b/docs/03-kubernetes-infrastructure.md
@@ -14,7 +14,7 @@ A Kubernetes 1.7.3+ cluster is required to host the Nomad control plane componen
 gcloud container clusters create nomad \
   --cluster-version 1.7.3 \
   --machine-type n1-standard-1 \
-  --num-nodes 3
+  --num-nodes 4
 ```
 
 It can take several minutes to provision the `nomad` Kubernetes cluster. Either wait for the above command to complete or use the `gcloud` command to monitor progress in a separate terminal:

--- a/docs/08-nomad-worker-nodes.md
+++ b/docs/08-nomad-worker-nodes.md
@@ -31,7 +31,7 @@ gcloud compute instance-templates create nomad-instance-template \
   --can-ip-forward \
   --image-family ubuntu-1604-lts \
   --image-project ubuntu-os-cloud \
-  --machine-type n1-standard-2 \
+  --machine-type n1-standard-1 \
   --metadata "gossip-encryption-key=${GOSSIP_ENCRYPTION_KEY},consul-internal-ip=${CONSUL_INTERNAL_IP}" \
   --metadata-from-file "startup-script=nomad.sh,ca-cert=ca.pem,consul-cert=consul.pem,consul-key=consul-key.pem,nomad-cert=nomad.pem,nomad-key=nomad-key.pem" \
   --scopes default,compute-ro \

--- a/statefulsets/consul.yaml
+++ b/statefulsets/consul.yaml
@@ -98,8 +98,8 @@ spec:
               protocol: "TCP"
           resources:
             requests:
-              cpu: "250m"
-              memory: "1Gi"
+              cpu: "125m"
+              memory: "512Mi"
       terminationGracePeriodSeconds: 10
       securityContext:
         fsGroup: 1000

--- a/statefulsets/nomad.yaml
+++ b/statefulsets/nomad.yaml
@@ -47,8 +47,8 @@ spec:
               protocol: "UDP"
           resources:
             requests:
-              cpu: "500m"
-              memory: "1Gi"
+              cpu: "250m"
+              memory: "512Mi"
           volumeMounts:
             - name: nomad-config
               mountPath: /etc/nomad/nomad.d
@@ -83,8 +83,8 @@ spec:
             - "-retry-join=consul-2.consul.$(NAMESPACE).svc.cluster.local"
           resources:
             requests:
-              cpu: "250m"
-              memory: "1Gi"
+              cpu: "125m"
+              memory: "512Mi"
           volumeMounts:
             - name: consul-config
               mountPath: /etc/consul/config

--- a/statefulsets/vault.yaml
+++ b/statefulsets/vault.yaml
@@ -42,8 +42,8 @@ spec:
               protocol: "TCP"
           resources:
             requests:
-              cpu: "500m"
-              memory: "1Gi"
+              cpu: "250m"
+              memory: "512Mi"
           securityContext:
             capabilities:
               add:
@@ -78,8 +78,8 @@ spec:
             - "-retry-join=consul-2.consul.$(NAMESPACE).svc.cluster.local"
           resources:
             requests:
-              cpu: "250m"
-              memory: "1Gi"
+              cpu: "125m"
+              memory: "512i"
           volumeMounts:
             - name: consul-config
               mountPath: /etc/consul/config

--- a/statefulsets/vault.yaml
+++ b/statefulsets/vault.yaml
@@ -79,7 +79,7 @@ spec:
           resources:
             requests:
               cpu: "125m"
-              memory: "512i"
+              memory: "512Mi"
           volumeMounts:
             - name: consul-config
               mountPath: /etc/consul/config


### PR DESCRIPTION
Given that the Google Cloud Free Trial only offers 8 CPUs in a single region, it's impossible to run the entire cluster with 2-CPU machines with a new account. I changed the machine types from `n1-standard-2` to `n1-standard-1` to reduce CPUs from 2 to 1 for each machine, and halved the resources in the `statefulsets` files to match. I did have to add a fourth node to the `default-pool` in the nomad cluster to account for all running Nomad containers.

I didn't dig too deep to figure out if there's a better layout, but given that all the services can run with reduced resources, I think this is a good start.

Please let me know if you have any issues with my proposed changes here. Having limited experience with k8s and virtually none with Vault, Consul, and Nomad, I'm eager to learn more.
 